### PR TITLE
Use “Keep A CHANGELOG” format for CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,58 +1,105 @@
-1.0.8
------
-* Run against iojs - @jkrems #27
+# Change Log
 
-1.0.7
------
-* Added CSON package which now uses cson-parser - @balupton
+
+
+## [1.0.8] - (2015-02-09)
+- Run against iojs - @jkrems #27
+
+
+
+## [1.0.7] - (2015-02-05)
+
+### Added
+- Added CSON package which now uses cson-parser - @balupton
   https://github.com/groupon/cson-parser/pull/25
 
-1.0.6
------
-* Rename to cson-parser - @jkrems
+
+
+## [1.0.6] - (2015-02-03)
+
+### Changed
+- Rename to cson-parser - @jkrems
   https://github.com/groupon/cson-parser/pull/23
 
-1.0.5
------
-* Be explicit about registry for publish - @jkrems
+
+
+## [1.0.5] - (2015-01-29)
+- Be explicit about registry for publish - @jkrems
   https://github.com/groupon/cson-safe/pull/19
-* Unify `''`/`""` handling, str.charAt(0) -> str[0] - @jkrems
+- Unify `''`/`""` handling, str.charAt(0) -> str[0] - @jkrems
   https://github.com/groupon/cson-safe/pull/22
 
-1.0.4
------
-* Use `vm.runInThisContext` instead of eval - @jkrems
+
+
+## [1.0.4] - (2015-01-12)
+
+### Changed
+- Use `vm.runInThisContext` instead of eval - @jkrems
   https://github.com/groupon/cson-safe/pull/18
 
-1.0.3
------
-* Add license SPDX ID to package.json - @jkrems
+
+
+## [1.0.3] - (2015-01-09)
+
+### Added
+- Add license SPDX ID to package.json - @jkrems
   https://github.com/groupon/cson-safe/pull/16
 
-1.0.2
------
-* Upgrade npub - @abloom
+
+
+## [1.0.2] - (2014-12-09)
+
+### Changed
+- Upgrade npub - @abloom
   https://github.com/groupon/cson-safe/pull/14
 
-v1.0.1
-------
-* Even nicer stringify with less noise - @jkrems
+
+
+## [1.0.1] - (2014-12-05)
+
+### Changed
+- Even nicer stringify with less noise - @jkrems
   https://github.com/groupon/cson-safe/pull/13
 
-v1.0.0
-------
-* Switch to coffee-script for parsing - @jkrems
+
+
+## [1.0.0] - (2014-12-03)
+
+### Changed
+- Switch to coffee-script for parsing - @jkrems
   https://github.com/groupon/cson-safe/pull/10
 
-v0.2.0
-------
-* A nicer CSON.stringify - @johan
+
+
+## [0.2.0] - (2014-12-02)
+
+### Changed
+- A nicer CSON.stringify - @johan
   https://github.com/groupon/cson-safe/pull/9
 
-v0.1.1
-------
-* Fix package meta data
 
-v0.1.0
-------
-* Initial public release
+
+## [0.1.1] - (2014-03-06)
+
+### Fixed
+- Fix package meta data
+
+
+
+## 0.1.0 - (2014-03-06)
+
+### Added
+- Initial public release
+
+
+[1.0.8]: https://github.com/groupon/cson-parser/compare/v1.0.8...v1.0.7
+[1.0.7]: https://github.com/groupon/cson-parser/compare/v1.0.7...v1.0.6
+[1.0.6]: https://github.com/groupon/cson-parser/compare/v1.0.6...v1.0.5
+[1.0.5]: https://github.com/groupon/cson-parser/compare/v1.0.5...v1.0.4
+[1.0.4]: https://github.com/groupon/cson-parser/compare/v1.0.4...v1.0.3
+[1.0.3]: https://github.com/groupon/cson-parser/compare/v1.0.3...v1.0.2
+[1.0.2]: https://github.com/groupon/cson-parser/compare/v1.0.2...v1.0.1
+[1.0.1]: https://github.com/groupon/cson-parser/compare/v1.0.1...v1.0.0
+[1.0.0]: https://github.com/groupon/cson-parser/compare/v1.0.0...v0.2.0
+[0.2.0]: https://github.com/groupon/cson-parser/compare/v0.2.0...v0.1.1
+[0.1.1]: https://github.com/groupon/cson-parser/compare/v0.1.1...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,14 +92,14 @@
 - Initial public release
 
 
-[1.0.8]: https://github.com/groupon/cson-parser/compare/v1.0.8...v1.0.7
-[1.0.7]: https://github.com/groupon/cson-parser/compare/v1.0.7...v1.0.6
-[1.0.6]: https://github.com/groupon/cson-parser/compare/v1.0.6...v1.0.5
-[1.0.5]: https://github.com/groupon/cson-parser/compare/v1.0.5...v1.0.4
-[1.0.4]: https://github.com/groupon/cson-parser/compare/v1.0.4...v1.0.3
-[1.0.3]: https://github.com/groupon/cson-parser/compare/v1.0.3...v1.0.2
-[1.0.2]: https://github.com/groupon/cson-parser/compare/v1.0.2...v1.0.1
-[1.0.1]: https://github.com/groupon/cson-parser/compare/v1.0.1...v1.0.0
-[1.0.0]: https://github.com/groupon/cson-parser/compare/v1.0.0...v0.2.0
-[0.2.0]: https://github.com/groupon/cson-parser/compare/v0.2.0...v0.1.1
-[0.1.1]: https://github.com/groupon/cson-parser/compare/v0.1.1...v0.1.0
+[1.0.8]: https://github.com/groupon/cson-parser/compare/v1.0.7...v1.0.8
+[1.0.7]: https://github.com/groupon/cson-parser/compare/v1.0.6...v1.0.7
+[1.0.6]: https://github.com/groupon/cson-parser/compare/v1.0.5...v1.0.6
+[1.0.5]: https://github.com/groupon/cson-parser/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/groupon/cson-parser/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/groupon/cson-parser/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/groupon/cson-parser/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/groupon/cson-parser/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/groupon/cson-parser/compare/v0.2.0...v1.0.0
+[0.2.0]: https://github.com/groupon/cson-parser/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/groupon/cson-parser/compare/v0.1.0...v0.1.1


### PR DESCRIPTION
It’s not a formal standard, but I think it should be: 

http://keepachangelog.com

It’s basically a collection of sensible things for keeping a changelog meaningful and optimizing human readability.