### PR TITLE
Parser no longer requires support for constructor.name

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -41,7 +41,13 @@ defaultReviver = function(key, value) {
 };
 
 nodeTypeString = function(csNode) {
-  return csNode.constructor.name;
+  var str;
+  if (csNode.constructor.name !== void 0) {
+    return csNode.constructor.name;
+  } else {
+    str = csNode.constructor.toString();
+    return str.match(/^function\s*([^( ]+)/)[1];
+  }
 };
 
 syntaxErrorMessage = function(csNode, msg) {

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -37,7 +37,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 defaultReviver = (key, value) -> value
 
 nodeTypeString = (csNode) ->
-  csNode.constructor.name
+  unless csNode.constructor.name == undefined
+    csNode.constructor.name
+  else
+    str = csNode.constructor.toString()
+    str.match(/^function\s*([^( ]+)/)[1]
 
 syntaxErrorMessage = (csNode, msg) ->
   {


### PR DESCRIPTION
The parse method would throw an exception in IE, since IE does not support constructor.name.

To make the parser work in IE, it is now first checked if constructor.name is present, otherwise the constructor name will be found by searching through constructor.toString().

I couldn't think of an obvious way to simulate not having constructor.name, so there's unfortunately no test for this fix. If you have any ideas as to how we can test the fix, please provide them to me, and I'll write a test.