### PR TITLE
Parser no longer requires support for constructor.name

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -30,7 +30,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var defaultReviver, nodeTypeString, nodes, parse, parseRegExpLiteral, parseStringLiteral, runInThisContext, syntaxErrorMessage;
+var defaultReviver, getFunctionNameIE, nodeTypeString, nodes, parse, parseRegExpLiteral, parseStringLiteral, runInThisContext, syntaxErrorMessage;
 
 runInThisContext = require('vm').runInThisContext;
 
@@ -40,8 +40,13 @@ defaultReviver = function(key, value) {
   return value;
 };
 
+getFunctionNameIE = function(fn) {
+  return csNode.constructor.toString().match(/^function\s*([^( ]+)/)[1];
+};
+
 nodeTypeString = function(csNode) {
-  return csNode.constructor.name;
+  var ref;
+  return (ref = csNode.constructor.name) != null ? ref : getFunctionNameIE(csNode.constructor);
 };
 
 syntaxErrorMessage = function(csNode, msg) {

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -36,8 +36,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 defaultReviver = (key, value) -> value
 
+getFunctionNameIE = (fn) ->
+  # fn.name is only standard in ES2015+ and won't work in IE
+  # This takes the source of the function and extracts the name,
+  # e.g. 'function fooBar ()' becomes fooBar.
+  csNode.constructor.toString()
+    .match(/^function\s*([^( ]+)/)[1]
+
 nodeTypeString = (csNode) ->
-  csNode.constructor.name
+  csNode.constructor.name ? getFunctionNameIE(csNode.constructor)
 
 syntaxErrorMessage = (csNode, msg) ->
   {


### PR DESCRIPTION
Fixes https://github.com/groupon/cson-parser/pull/51