### PR TITLE
Make single quotes the default in stringify

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -34,6 +34,10 @@ var jsIdentifierRE = /^[a-z_$][a-z0-9_$]*$/i;
 var tripleQuotesRE = /'''/g;
 var SPACES = '          ';
 
+function contains(str1, str2) {
+  return str1.indexOf(str2) >= 0;
+}
+
 function newlineWrap(str) {
   return str && ('\n' + str + '\n');
 }
@@ -65,11 +69,30 @@ function indentLines(indent, str) {
   return str.split('\n').map(indentLine.bind(null, indent)).join('\n');
 }
 
+function singleQuoteStringify(str) {
+  return "'"
+       + JSON.stringify(str)
+             .slice(1, -1)
+             .replace(/\\"/g, '"')
+             .replace(/'/g, "\\'")
+       + "'";
+}
+
+function quoteType(str) {
+  return contains(str, "'") && !contains(str, '"') ? 'double' : 'single';
+}
+
+function onelineStringify(str) {
+  return (
+    quoteType(str) === 'single' ? singleQuoteStringify : JSON.stringify
+  )(str);
+}
+
 function buildKeyPairs(visitNode, indent, obj) {
   return Object.keys(obj).map(function addKey(key) {
     var value = obj[key];
     if (!key.match(jsIdentifierRE)) {
-      key = JSON.stringify(key);
+      key = onelineStringify(key);
     }
     var serializedValue = visitNode(value, {
       bracesRequired: !indent
@@ -117,7 +140,7 @@ function visitObject(visitNode, indent, obj, arg) {
 function visitString(visitNode, indent, str) {
   var string;
   if (str.indexOf('\n') === -1 || !indent) {
-    return JSON.stringify(str);
+    return onelineStringify(str);
   }
   string = str.replace(/\\/g, '\\\\').replace(tripleQuotesRE, "\\'''");
   return "'''" + (newlineWrap(indentLines(indent, string))) + "'''";

--- a/test/stringify.test.coffee
+++ b/test/stringify.test.coffee
@@ -24,7 +24,7 @@ describe 'CSON.stringify', ->
     equal '1.2e+90', cson 1.2e+90
 
   it 'handles single-line strings', ->
-    equal '"hello!"', cson 'hello!'
+    equal "'hello!'", cson 'hello!'
 
   it 'handles multi-line strings', ->
     equal """
@@ -60,7 +60,7 @@ describe 'CSON.stringify', ->
         null
         []
         {
-          a: "str"
+          a: 'str'
         }
         {}
       ]
@@ -68,17 +68,17 @@ describe 'CSON.stringify', ->
 
   it 'handles arrays (with 0 indentation)', ->
     equal '''
-    [[1],null,[],{a:"str"},{}]
+    [[1],null,[],{a:'str'},{}]
     ''', cson [ [1], null, [], a: 'str', {} ], null, 0
 
   it 'handles objects', ->
     equal '''
-      "": "empty"
-      "non\\nidentifier": true
+      '': 'empty'
+      'non\\nidentifier': true
       default: false
       emptyObject: {}
       nested:
-        string: "too"
+        string: 'too'
       array: [
         {}
         []
@@ -99,7 +99,7 @@ describe 'CSON.stringify', ->
 
   it 'handles objects (with 0 indentation)', ->
     equal '''
-    "":"empty","non\\nidentifier":true,default:false,nested:{string:"too"},array:[{},[]]
+    '':'empty','non\\nidentifier':true,default:false,nested:{string:'too'},array:[{},[]]
     ''', cson {
       '': 'empty'
       "non\nidentifier": true
@@ -133,7 +133,7 @@ describe 'CSON.stringify', ->
   it 'lets people that really want to indent with tabs', ->
     equal '''
       x:
-      \t\t"super-tabby": true
+      \t\t'super-tabby': true
     ''', cson { x: { 'super-tabby': yes } }, null, '\t\t'
 
   it 'handles indentation by NaN', ->


### PR DESCRIPTION
BREAKING CHANGE: The default used to be double quotes.

See the discussion here: https://github.com/groupon/cson-parser/issues/62