### PR TITLE
chore: Use coffeescript instead of coffee-script

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -33,7 +33,7 @@
 'use strict';
 
 var runInThisContext = require('vm').runInThisContext;
-var nodes = require('coffee-script').nodes;
+var nodes = require('coffeescript').nodes;
 
 function defaultReviver(key, value) {
   return value;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "coffee-script": "^1.10.0"
+    "coffeescript": "^1.10.0"
   },
   "devDependencies": {
     "assertive": "^2.1.0",


### PR DESCRIPTION
BREAKING CHANGE: Since coffeescript contains a conflicting `./bin`
symlink for the `coffee` command line tool, do *not* install this
version of `cson-parser` while you still have `coffee-script`
anywhere in your dependency tree.

Fixes https://github.com/groupon/cson-parser/issues/67