### PR TITLE
insert backslash to double quotes instead of triple quotes

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -33,7 +33,7 @@
 'use strict';
 
 const jsIdentifierRE = /^[a-z_$][a-z0-9_$]*$/i;
-const tripleQuotesRE = /'''/g;
+const doubleQuotesRE = /''/g;
 const SPACES = '          ';
 
 function contains(str1, str2) {
@@ -147,7 +147,7 @@ function visitString(visitNode, indent, str) {
   if (str.indexOf('\n') === -1 || !indent) {
     return onelineStringify(str);
   }
-  const string = str.replace(/\\/g, '\\\\').replace(tripleQuotesRE, "\\'''");
+  const string = str.replace(/\\/g, '\\\\').replace(doubleQuotesRE, "\\''");
   return `'''${newlineWrap(indentLines(indent, string))}'''`;
 }
 

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -46,6 +46,20 @@ and I have a sneaky ''' in here, too\
 `)
     ));
 
+  it('handles multi-line strings with quad quotes', () =>
+    equal(
+      `\
+'''
+  I am your average multi-line string,
+  and I have a sneaky \\''\\'' in here, too
+'''\
+`,
+      cson(`\
+I am your average multi-line string,
+and I have a sneaky '''' in here, too\
+`)
+    ));
+
   it('handles multi-line strings (with 0 indentation)', () =>
     equal(
       `\


### PR DESCRIPTION
# Issue
#75 

# Motivation
Instead of adding backslash to the first quote, add the backslash to the last quote can solve the problem.


